### PR TITLE
iotlab- entrypoints, 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ cover/
 
 # Generated json files
 *.json
+
+.idea/
+.pytest_cache/

--- a/iotlab-oml-plot-consum
+++ b/iotlab-oml-plot-consum
@@ -19,8 +19,7 @@
 #
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
-from iotlabcli.helpers import deprecate_cmd
 
-import oml_plot_tools.traj
+import oml_plot_tools.consum
 
-deprecate_cmd(oml_plot_tools.traj.main, "plot_oml_traj", "iotlab-oml-plot-traj")
+oml_plot_tools.consum.main()

--- a/iotlab-oml-plot-consum
+++ b/iotlab-oml-plot-consum
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/iotlab-oml-plot-radio
+++ b/iotlab-oml-plot-radio
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/iotlab-oml-plot-radio
+++ b/iotlab-oml-plot-radio
@@ -19,8 +19,7 @@
 #
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
-from iotlabcli.helpers import deprecate_cmd
 
-import oml_plot_tools.traj
+import oml_plot_tools.radio
 
-deprecate_cmd(oml_plot_tools.traj.main, "plot_oml_traj", "iotlab-oml-plot-traj")
+oml_plot_tools.radio.main()

--- a/iotlab-oml-plot-traj
+++ b/iotlab-oml-plot-traj
@@ -19,8 +19,7 @@
 #
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
-from iotlabcli.helpers import deprecate_cmd
 
 import oml_plot_tools.traj
 
-deprecate_cmd(oml_plot_tools.traj.main, "plot_oml_traj", "iotlab-oml-plot-traj")
+oml_plot_tools.traj.main()

--- a/iotlab-oml-plot-traj
+++ b/iotlab-oml-plot-traj
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/__init__.py
+++ b/oml_plot_tools/__init__.py
@@ -21,4 +21,4 @@
 
 """ List of tools to display iot-lab oml generated files """
 
-__version__ = '0.6.0'
+__version__ = '0.7.0'

--- a/oml_plot_tools/__init__.py
+++ b/oml_plot_tools/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/common.py
+++ b/oml_plot_tools/common.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/consum.py
+++ b/oml_plot_tools/consum.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/radio.py
+++ b/oml_plot_tools/radio.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/__init__.py
+++ b/oml_plot_tools/tests/__init__.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/common.py
+++ b/oml_plot_tools/tests/common.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/common_test.py
+++ b/oml_plot_tools/tests/common_test.py
@@ -1,7 +1,7 @@
 # -*- coding:utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/consum_test.py
+++ b/oml_plot_tools/tests/consum_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/radio_test.py
+++ b/oml_plot_tools/tests/radio_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/tests/traj_test.py
+++ b/oml_plot_tools/tests/traj_test.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/oml_plot_tools/traj.py
+++ b/oml_plot_tools/traj.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/plot_oml_consum
+++ b/plot_oml_consum
@@ -19,6 +19,8 @@
 #
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
+from iotlabcli.helpers import deprecate_cmd
 
 import oml_plot_tools.consum
-oml_plot_tools.consum.main()
+
+deprecate_cmd(oml_plot_tools.consum.main, "plot_oml_consum", "iotlab-oml-plot-consum")

--- a/plot_oml_consum
+++ b/plot_oml_consum
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/plot_oml_radio
+++ b/plot_oml_radio
@@ -19,6 +19,8 @@
 #
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
+from iotlabcli.helpers import deprecate_cmd
 
 import oml_plot_tools.radio
-oml_plot_tools.radio.main()
+
+deprecate_cmd(oml_plot_tools.radio.main, "plot_oml_radio", "iotlab-oml-plot-radio")

--- a/plot_oml_radio
+++ b/plot_oml_radio
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/plot_oml_traj
+++ b/plot_oml_traj
@@ -2,7 +2,7 @@
 # -*- coding:utf8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,14 @@ def get_version(package):
                 return eval(line.split('=')[-1])  # pylint:disable=eval-used
 
 
-SCRIPTS = ['plot_oml_consum', 'plot_oml_radio', 'plot_oml_traj']
+SCRIPTS = ['iotlab-oml-plot-consum', 'iotlab-oml-plot-radio',
+           'iotlab-oml-plot-traj']
+DEPRECATED_SCRIPTS = ['plot_oml_consum', 'plot_oml_radio', 'plot_oml_traj']
+
+SCRIPTS += DEPRECATED_SCRIPTS
 
 INSTALL_REQUIRES = ['argparse', 'numpy', 'matplotlib', 'Pillow']
-INSTALL_REQUIRES += ['iotlabcli>=2.0.0']
+INSTALL_REQUIRES += ['iotlabcli >= 2.5.0']
 if sys.version_info[0:2] == (2, 6):
     # OrderedDict added in python2.7
     INSTALL_REQUIRES.append('ordereddict')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 # -*- coding:utf-8 -*-
 
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/tests_utils/COPYING_HEADER
+++ b/tests_utils/COPYING_HEADER
@@ -1,5 +1,5 @@
 # This file is a part of IoT-LAB oml-plot-tools
-# Copyright (C) 2015 INRIA (Contact: admin@iot-lab.info)
+# Copyright (C) 2018 INRIA (Contact: admin@iot-lab.info)
 # Contributor(s) : see AUTHORS file
 #
 # This software is governed by the CeCILL license under French law

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands=
 [testenv:cli]
 whitelist_externals = /bin/bash
 commands=
-    bash -exc "for i in plot_oml_*; do $i --help >/dev/null; done"
+    bash -exc "for i in iotlab-oml-plot-*; do $i --help >/dev/null; done"
 
 [testenv:code_check]
 deps=


### PR DESCRIPTION
Updating the oml plot tools with the same iotlab-* system. 
Bump dependency to cli-tools 2.5.0 to get the deprecation helper
Release that in 0.7.0 ? That way, updating the tutorial to use iotlab-oml-plot-* stuff
