### PR TITLE
Add Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,18 @@
 language: python
+dist: xenial
 
 python: 2.7
+
+matrix:
+  include:
+    - python: 2.7
+      env: TOXENV="copying,cli,py27,coverage"
+    - python: 3.5
+      env: TOXENV="copying,cli,py35"
+    - python: 3.6
+      env: TOXENV="copying,cli,py36"
+    - python: 3.7
+      env: TOXENV="copying,cli,py37,coverage"
 
 before_install:
   - pip install tox
@@ -9,4 +21,4 @@ install:
   - pip install .
 
 script:
-- tox -e copying,cli,py27,coverage
+  - tox

--- a/oml_plot_tools/common.py
+++ b/oml_plot_tools/common.py
@@ -97,14 +97,14 @@ def oml_plot_clock(data, title='Clock time verification'):
     time = data['timestamp']
     clock_diff = numpy.diff(time) * 1000
 
-    print 'Time from %f to %f' % (time[0], time[-1])
-    print 'NB Points      =', len(time)
-    print 'Duration    (s)=', time[-1] - time[0]
-    print 'Steptime   (ms)=', 1000 * (time[-1] - time[0]) / len(time)
-    print 'Clock mean (ms)=', numpy.mean(clock_diff)
-    print 'Clock std  (ms)=', numpy.std(clock_diff)
-    print 'Clock max  (ms)=', numpy.max(clock_diff)
-    print 'Clock min  (ms)=', numpy.min(clock_diff)
+    print('Time from %f to %f' % (time[0], time[-1]))
+    print('NB Points      =', len(time))
+    print('Duration    (s)=', time[-1] - time[0])
+    print('Steptime   (ms)=', 1000 * (time[-1] - time[0]) / len(time))
+    print('Clock mean (ms)=', numpy.mean(clock_diff))
+    print('Clock std  (ms)=', numpy.std(clock_diff))
+    print('Clock max  (ms)=', numpy.max(clock_diff))
+    print('Clock min  (ms)=', numpy.min(clock_diff))
 
     plt.figure()
     plt.title(title)

--- a/oml_plot_tools/common.py
+++ b/oml_plot_tools/common.py
@@ -25,12 +25,9 @@
 # Issues with numpy
 # pylint:disable=no-member
 
-from collections import namedtuple
-try:
-    # E0611: no name in module
-    from collections import OrderedDict  # pylint:disable=import-error,E0611
-except ImportError:  # pragma: no cover
-    from ordereddict import OrderedDict  # pylint:disable=import-error
+from __future__ import print_function
+
+from collections import namedtuple, OrderedDict
 
 import numpy
 import matplotlib.pyplot as plt

--- a/oml_plot_tools/tests/common.py
+++ b/oml_plot_tools/tests/common.py
@@ -27,7 +27,13 @@ from __future__ import print_function
 import os
 import math
 import runpy
-from cStringIO import StringIO
+
+try:
+    # pylint:disable=unused-import
+    from cStringIO import StringIO  # noqa
+except ImportError:  # Python 3
+    # pylint:disable=unused-import
+    from io import StringIO  # noqa
 
 import mock
 import matplotlib.pyplot as plt

--- a/oml_plot_tools/tests/common.py
+++ b/oml_plot_tools/tests/common.py
@@ -22,6 +22,8 @@
 
 """ Common tests functions """
 
+from __future__ import print_function
+
 import os
 import math
 import runpy

--- a/oml_plot_tools/tests/common.py
+++ b/oml_plot_tools/tests/common.py
@@ -126,10 +126,6 @@ def assert_called_with_nparray(mock_function, np_array, *args, **kwargs):
     call_array = call_args[0]
     call_args = call_args[1:]
 
-    # Failed to compare with '==', 'np.array_equal', or 'np.allclose'
-    got = call_array, call_args, call_kwargs
-    expected = np_array, args, kwargs
-    assert_string = '%s == %s' % (got, expected)
-
-    assert (repr(call_array), call_args, call_kwargs) == \
-        (repr(np_array), args, kwargs), assert_string
+    assert repr(call_array) == repr(np_array)
+    assert repr(call_args) == repr(args)
+    assert call_kwargs == kwargs

--- a/oml_plot_tools/tests/common.py
+++ b/oml_plot_tools/tests/common.py
@@ -59,8 +59,8 @@ def help_main_and_doc(module, help_opt='--help'):
 
     help_msg = out_msg.getvalue().strip()
     help_doc = module.__doc__.strip()
-    print help_msg
-    print help_doc
+    print(help_msg)
+    print(help_doc)
 
     return help_msg, help_doc
 

--- a/oml_plot_tools/tests/common_test.py
+++ b/oml_plot_tools/tests/common_test.py
@@ -23,7 +23,13 @@
 # pylint:disable=missing-docstring
 
 import unittest
-from cStringIO import StringIO
+
+try:
+    # pylint:disable=unused-import
+    from cStringIO import StringIO  # noqa
+except ImportError:  # Python 3
+    # pylint:disable=unused-import
+    from io import StringIO  # noqa
 
 # Issues with pylint and numpy
 # pylint:disable=no-member

--- a/oml_plot_tools/tests/consum_test.py
+++ b/oml_plot_tools/tests/consum_test.py
@@ -109,18 +109,14 @@ class TestConsumptionPlot(unittest.TestCase):
         assert_called_with_nparray(
             self.oml_plot,
             self.data, self.title,
-            [common.MeasureTuple('power', float, 'Power (W)'),
-             common.MeasureTuple('voltage', float, 'Voltage (V)'),
-             common.MeasureTuple('current', float, 'Current (A)')])
+            consum.MEASURES_D.values())
 
     def test_plot_default_all(self):
         self.consum_main()
         assert_called_with_nparray(
             self.oml_plot,
             self.data, self.title,
-            [common.MeasureTuple('power', float, 'Power (W)'),
-             common.MeasureTuple('voltage', float, 'Voltage (V)'),
-             common.MeasureTuple('current', float, 'Current (A)')])
+            consum.MEASURES_D.values())
 
     def test_plot_time(self):
         self.consum_main('-t')

--- a/oml_plot_tools/tests/traj_test.py
+++ b/oml_plot_tools/tests/traj_test.py
@@ -69,7 +69,7 @@ class TestTrajectoryOmlPlot(unittest.TestCase):
     def test_plot_all(self):
         ref_img = test_file_path('examples', 'trajectory_all.png')
         traj.oml_plot_map(self.data, self.title, self.mapinfo, self.circuit)
-        utest_plot_and_compare(self, ref_img, 250)
+        utest_plot_and_compare(self, ref_img, 600)
 
     def test_plot_traj_only(self):
         ref_img = test_file_path('examples', 'trajectory_only.png')
@@ -79,7 +79,7 @@ class TestTrajectoryOmlPlot(unittest.TestCase):
     def test_plot_traj_circuit(self):
         ref_img = test_file_path('examples', 'trajectory_circuit.png')
         traj.oml_plot_map(None, self.title, None, self.circuit)
-        utest_plot_and_compare(self, ref_img, 50)
+        utest_plot_and_compare(self, ref_img, 60)
 
     def test_plot_traj_nothing(self):
         ret = traj.oml_plot_map(None, None, None, None)

--- a/oml_plot_tools/traj.py
+++ b/oml_plot_tools/traj.py
@@ -215,7 +215,7 @@ def trajectory_plot(data, title, mapinfo, circuit, selection):
     if plot_data:
         common.plot_show()
     else:
-        print "Nothing to plot"
+        print("Nothing to plot")
 
 
 def oml_plot_angle(data, title, xlabel=common.TIMESTAMP_LABEL):

--- a/oml_plot_tools/traj.py
+++ b/oml_plot_tools/traj.py
@@ -48,6 +48,7 @@ plot:
   -ti, --time           Plot time verification
 """
 
+from __future__ import print_function
 
 import json
 import sys

--- a/oml_plot_tools/traj.py
+++ b/oml_plot_tools/traj.py
@@ -302,7 +302,7 @@ def _plot_circuit(circuit):
     coords = (coords_x, coords_y)
 
     # Get edges between checkpoints
-    edges = patches.Polygon(zip(*coords), **CIRCUIT_EDGE_PLT)
+    edges = patches.Polygon(list(zip(*coords)), **CIRCUIT_EDGE_PLT)
 
     # Plot
     a_x = plt.gcf().add_subplot(111)

--- a/oml_plot_tools/traj.py
+++ b/oml_plot_tools/traj.py
@@ -52,10 +52,11 @@ from __future__ import print_function
 
 import json
 import sys
-from collections import namedtuple
-from cStringIO import StringIO
 
 import argparse
+
+from collections import namedtuple
+from io import BytesIO
 
 # Issues with numpy and matplotlib.cm
 # pylint:disable=no-member
@@ -131,7 +132,7 @@ def _mapinfo_from_cfg(map_cfg):
     """ MapInfo object from 'map_cfg' dict """
 
     # Load Image
-    image_fd = StringIO(map_cfg['image'])
+    image_fd = BytesIO(map_cfg['image'])
     image = Image.open(image_fd).convert('L')
 
     # Load Docks

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@
 # The fact that you are presently reading this means that you have had
 # knowledge of the CeCILL license and that you accept its terms.
 
-import sys
 import os
 from setuptools import setup, find_packages
 
@@ -47,9 +46,6 @@ SCRIPTS = ['plot_oml_consum', 'plot_oml_radio', 'plot_oml_traj']
 
 INSTALL_REQUIRES = ['argparse', 'numpy', 'matplotlib', 'Pillow']
 INSTALL_REQUIRES += ['iotlabcli>=2.0.0']
-if sys.version_info[0:2] == (2, 6):
-    # OrderedDict added in python2.7
-    INSTALL_REQUIRES.append('ordereddict')
 
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,18 @@
 [tox]
 envlist = copying,cli,py27,py35,py36,py37
-
-[tox:jenkins]
 skip_missing_interpreters = True
 
 [testenv:copying]
-whitelist_externals = /bin/bash
+whitelist_externals=
+    /bin/bash
+    /usr/bin/bash
 commands=
     bash tests_utils/check_license.sh
 
 [testenv:cli]
-whitelist_externals = /bin/bash
+whitelist_externals=
+    /bin/bash
+    /usr/bin/bash
 commands=
     bash -exc "for i in plot_oml_*; do $i --help >/dev/null; done"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = copying,cli,py27
+envlist = copying,cli,py27,py35,py36,py37
 
 [tox:jenkins]
 skip_missing_interpreters = True
@@ -30,7 +30,7 @@ deps=
     -rrequirements.txt
     -rtests_utils/test-requirements.txt
 commands=
-    pytest
+    pytest {posargs}
     -python setup.py lint
     flake8
 


### PR DESCRIPTION
- Enable Python 3 compatibility
- Add Python 3 testenv in Tox
- Enable multiple Python 3 jobs in Travis
- Remove Python 2.6 backward compatibility code (not needed anymore)